### PR TITLE
proxy: handle error values

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -249,6 +249,8 @@ func spoofResponse(config *SpoofingConfig, requestBytes []byte, responseBody io.
 		switch {
 		case strings.Contains(err.Error(), "cannot unmarshal array"):
 			return responseBytes, nil
+		case strings.Contains(err.Error(), "invalid character"):
+			return nil, errors.New(string(responseBytes))
 		default:
 			return nil, err
 		}
@@ -258,6 +260,8 @@ func spoofResponse(config *SpoofingConfig, requestBytes []byte, responseBody io.
 		switch {
 		case strings.Contains(err.Error(), "cannot unmarshal array"):
 			return responseBytes, nil
+		case strings.Contains(err.Error(), "invalid character"):
+			return nil, errors.New(string(responseBytes))
 		default:
 			return nil, err
 		}


### PR DESCRIPTION
Geth will return values like "missing token" or "stale token" if something with the token is bad. 
The error returned from the json marshalling is something like `[e11a24a7] time="2022-05-11T13:25:26Z" level=error msg="Failed to Spoof response" error="invalid character 's' looking for beginning of value"` though, which is not really useful.
So if the marshalling fails with "invalid character" we should just return a new error with what the peer send us
